### PR TITLE
Set up for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy Backend to Railway
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy to Railway
+        uses: bervProject/railway-deploy@main
+        with:
+          railway_token: ${{ secrets.RAILWAY_TOKEN }}
+          service: ${{ secrets.RAILWAY_SERVICE_NAME }}

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,403 @@
+# FitGPT Deployment Guide
+
+Complete guide to deploying your FitGPT workout app for personal use on iPhone.
+
+## Architecture Overview
+
+- **Backend**: Node.js/Express API deployed on Railway.app
+- **Database**: MongoDB Atlas (existing instance)
+- **Frontend**: React Native (Expo) on iPhone via Expo Go
+- **Updates**: Over-the-air (OTA) updates via Expo
+
+---
+
+## One-Time Setup
+
+### 1. Backend Deployment on Railway (~15 minutes)
+
+#### A. Create Railway Account
+1. Go to [railway.app](https://railway.app)
+2. Sign up with GitHub (recommended)
+3. Verify your email
+
+#### B. Deploy Backend
+1. Click **"New Project"**
+2. Select **"Deploy from GitHub repo"**
+3. Choose your `fit-gpt` repository
+4. Railway will detect your Node.js app
+
+#### C. Configure Railway Service
+1. In your Railway project, click on the service
+2. Go to **Settings** → **Root Directory**
+   - Set to: `backend`
+3. Go to **Settings** → **Build Command**
+   - Set to: `npm install && npm run build`
+4. Go to **Settings** → **Start Command**
+   - Set to: `npm start`
+
+#### D. Set Environment Variables
+1. Go to **Variables** tab
+2. Add the following variables:
+
+```bash
+NODE_ENV=production
+PORT=3000
+MONGODB_URI=your-mongodb-atlas-connection-string-here
+JWT_SECRET=your-generated-secret-here
+JWT_EXPIRES_IN=7d
+CORS_ORIGIN=*
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+```
+
+**To generate JWT_SECRET:**
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+**MongoDB URI**: Use your existing MongoDB Atlas connection string
+
+**Anthropic API Key**: Get from [console.anthropic.com](https://console.anthropic.com)
+
+#### E. Get Your Railway URL
+1. Go to **Settings** → **Domains**
+2. Click **Generate Domain**
+3. Copy your Railway URL (e.g., `https://fit-gpt-production.up.railway.app`)
+4. **Save this URL** - you'll need it for the frontend!
+
+#### F. Verify Deployment
+Visit your Railway URL + `/health`:
+```
+https://your-app.up.railway.app/health
+```
+
+You should see:
+```json
+{
+  "status": "ok",
+  "timestamp": "2025-11-05T...",
+  "environment": "production"
+}
+```
+
+---
+
+### 2. Setup GitHub Auto-Deploy (~5 minutes)
+
+#### A. Get Railway Token
+1. Go to [railway.app/account/tokens](https://railway.app/account/tokens)
+2. Click **"Create Token"**
+3. Give it a name (e.g., "GitHub Actions")
+4. Copy the token immediately (you won't see it again!)
+
+#### B. Get Service Name
+1. In your Railway project, go to your backend service
+2. Click on **Settings** → **Service ID**
+3. Copy the service ID (this is your service name)
+
+#### C. Add GitHub Secrets
+1. Go to your GitHub repository
+2. Click **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Add two secrets:
+   - `RAILWAY_TOKEN`: Paste your Railway token
+   - `RAILWAY_SERVICE_NAME`: Paste your service ID
+
+#### D. Test Auto-Deploy
+1. Make a small change to `backend/README.md`
+2. Commit and push to `main`:
+   ```bash
+   git add backend/README.md
+   git commit -m "Test auto-deploy"
+   git push origin main
+   ```
+3. Go to **Actions** tab in GitHub to watch the deployment
+4. Check Railway dashboard to verify new deployment
+
+**That's it!** Every push to `main` will now auto-deploy your backend.
+
+---
+
+### 3. Frontend Setup for iPhone (~10 minutes)
+
+#### A. Install Expo Go on iPhone
+1. Open App Store
+2. Search for "Expo Go"
+3. Install the app (it's free)
+
+#### B. Create Expo Account
+1. Go to [expo.dev](https://expo.dev)
+2. Sign up (free account)
+3. Verify your email
+
+#### C. Login to Expo CLI
+```bash
+cd frontend
+npx expo login
+```
+Enter your Expo credentials.
+
+#### D. Configure EAS (Expo Application Services)
+```bash
+npx eas-cli@latest init
+```
+
+This will:
+- Create an Expo project
+- Add project ID to `app.json`
+- Configure OTA updates
+
+#### E. Update Production Backend URL
+Edit `frontend/app.json`:
+
+```json
+"extra": {
+  "eas": {
+    "projectId": "your-project-id-from-eas-init"
+  },
+  "apiBaseUrl": "https://your-railway-url.railway.app/api"
+}
+```
+
+Replace `your-railway-url.railway.app` with your actual Railway URL from step 1.E.
+
+#### F. Initial Publish
+```bash
+cd frontend
+npm run publish
+```
+
+This will bundle your app and publish it to Expo's servers.
+
+#### G. Open App on iPhone
+1. Open Expo Go app on your iPhone
+2. Sign in with your Expo account
+3. Your app "FitGPT" should appear in your projects
+4. Tap to open it!
+
+**Alternative**: Scan the QR code from `npx expo start`
+
+---
+
+## Regular Usage
+
+### Updating the Backend
+
+Just push to `main`:
+```bash
+git add .
+git commit -m "Your changes"
+git push origin main
+```
+
+GitHub Actions will auto-deploy to Railway (~2-3 minutes).
+
+### Updating the Frontend (App Updates)
+
+#### Quick Update (recommended):
+```bash
+cd frontend
+npm run update
+```
+
+Your iPhone app will automatically update next time you open it!
+
+#### Full Republish:
+```bash
+cd frontend
+npm run publish
+```
+
+### Development Workflow
+
+#### Backend Development:
+```bash
+cd backend
+npm run dev
+```
+
+#### Frontend Development:
+```bash
+cd frontend
+npm start
+```
+
+Then:
+- Press `i` for iOS simulator (if you have Xcode)
+- Or scan QR code with Expo Go app
+
+Changes will hot-reload instantly!
+
+---
+
+## Monitoring & Troubleshooting
+
+### Check Backend Logs
+1. Go to Railway dashboard
+2. Click on your backend service
+3. Click **Deployments**
+4. View logs in real-time
+
+### Check Backend Health
+```bash
+curl https://your-railway-url.railway.app/health
+```
+
+### Common Issues
+
+#### Backend not responding
+- Check Railway logs
+- Verify environment variables are set
+- Check MongoDB Atlas connection (whitelist Railway IPs: `0.0.0.0/0`)
+
+#### Frontend can't connect to backend
+- Check `frontend/app.json` → `extra.apiBaseUrl`
+- Check backend CORS settings
+- View network requests in Expo debugger: shake phone → "Debug Remote JS"
+
+#### App not updating
+- Make sure you published: `npm run update`
+- Clear Expo Go cache: Long-press app → Clear cache
+- Re-publish with new version number
+
+### MongoDB Atlas Setup (if needed)
+
+If you need to set up a new MongoDB Atlas instance:
+
+1. Go to [mongodb.com/cloud/atlas](https://www.mongodb.com/cloud/atlas)
+2. Create free account
+3. Create a **FREE** cluster (M0)
+4. Go to **Database Access** → Add user (save password!)
+5. Go to **Network Access** → Add IP: `0.0.0.0/0` (allow from anywhere)
+6. Click **Connect** → **Connect your application**
+7. Copy connection string (format: `mongodb+srv://...`)
+8. Replace `<password>` with your actual password
+9. Add to Railway environment variables
+
+---
+
+## Cost Breakdown
+
+- **Railway**: $5/month (starter plan - no cold starts)
+- **MongoDB Atlas**: $0/month (free tier - 512MB)
+- **Expo**: $0/month (free tier)
+- **GitHub Actions**: $0/month (free for public repos)
+
+**Total: $5/month** (or $0 if you use Railway's hobby plan with cold starts)
+
+---
+
+## Alternative: Railway Free Tier
+
+Railway offers 500 hours/month free (plus $5 credit):
+- Should be enough for personal use
+- Your app will have ~15-30 second cold start after inactivity
+- To use free tier: Don't add payment method
+
+---
+
+## Security Notes
+
+1. **Never commit `.env` files** to Git (already in `.gitignore`)
+2. **Rotate JWT_SECRET** periodically
+3. **Keep Anthropic API key secure**
+4. **MongoDB**: Enable authentication (Atlas does by default)
+
+---
+
+## API Documentation
+
+Your backend includes Swagger docs!
+
+Visit: `https://your-railway-url.railway.app/api-docs`
+
+---
+
+## Advanced: Building Standalone App (Optional)
+
+If you want a standalone app instead of Expo Go:
+
+### For iPhone (Requires Apple Developer Account - $99/year)
+
+```bash
+cd frontend
+npx eas build --platform ios --profile preview
+```
+
+Then submit to TestFlight:
+```bash
+npx eas submit --platform ios
+```
+
+This creates a "real" app you can install via TestFlight.
+
+---
+
+## Quick Reference
+
+### Environment Variables
+
+**Backend** (Railway):
+```bash
+NODE_ENV=production
+PORT=3000
+MONGODB_URI=mongodb+srv://...
+JWT_SECRET=32-char-hex-string
+JWT_EXPIRES_IN=7d
+CORS_ORIGIN=*
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+**Frontend** (app.json):
+```json
+{
+  "extra": {
+    "apiBaseUrl": "https://your-railway-url.railway.app/api"
+  }
+}
+```
+
+### Common Commands
+
+```bash
+# Backend
+npm run dev          # Local development
+npm run build        # Build for production
+npm run start        # Start production server
+npm run type-check   # Check TypeScript
+
+# Frontend
+npm start            # Start Expo
+npm run publish      # Publish update
+npm run update       # Publish to production channel
+npm run type-check   # Check TypeScript
+
+# Git
+git push origin main # Triggers auto-deploy
+```
+
+---
+
+## Support
+
+- **Railway**: [docs.railway.app](https://docs.railway.app)
+- **Expo**: [docs.expo.dev](https://docs.expo.dev)
+- **MongoDB**: [docs.mongodb.com](https://docs.mongodb.com)
+
+---
+
+## Success Checklist
+
+- [ ] Railway backend deployed and health check passes
+- [ ] GitHub Actions auto-deploy working
+- [ ] MongoDB connected (check Railway logs)
+- [ ] Expo account created
+- [ ] EAS initialized
+- [ ] Frontend published to Expo
+- [ ] App opens on iPhone via Expo Go
+- [ ] Can create account and login
+- [ ] Can generate workout
+- [ ] OTA updates working
+
+---
+
+You're all set! 🎉 Enjoy your workouts!

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,7 +3,7 @@ NODE_ENV=development
 PORT=3000
 
 # Database
-MONGODB_URI=mongodb://localhost:27017/gen-workout
+MONGODB_URI=mongodb://localhost:27017/fit-gpt
 
 # JWT Configuration
 JWT_SECRET=your-secret-key-change-this-in-production
@@ -13,4 +13,4 @@ JWT_EXPIRES_IN=7d
 CORS_ORIGIN=http://localhost:3000
 
 # API Keys
-ANTHROPIC_API_KEY='your-api-key-here'
+ANTHROPIC_API_KEY=your-api-key-here

--- a/backend/.env.production.example
+++ b/backend/.env.production.example
@@ -1,0 +1,20 @@
+# Server Configuration
+NODE_ENV=production
+PORT=3000
+
+# Database
+# Your MongoDB Atlas connection string
+MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/fit-gpt?retryWrites=true&w=majority
+
+# JWT Configuration
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+JWT_SECRET=your-production-secret-key-here
+JWT_EXPIRES_IN=7d
+
+# CORS
+# Comma-separated list of allowed origins
+# Use * for development, specific domains for production
+CORS_ORIGIN=https://your-frontend-domain.com,exp://
+
+# API Keys
+ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gen-workout-backend",
+  "name": "fit-gpt-backend",
   "version": "1.0.0",
-  "description": "Backend for AI-integrated workout tracking app",
+  "description": "Backend for AI-integrated workout tracking app (FitGPT)",
   "main": "dist/server.js",
   "scripts": {
     "dev": "nodemon",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,8 +14,24 @@ const app: Application = express();
 app.use(helmet());
 
 // CORS configuration
+// Support multiple origins for production (comma-separated) and Expo Go
+const allowedOrigins = env.CORS_ORIGIN.split(',').map(origin => origin.trim());
+
 app.use(cors({
-  origin: env.CORS_ORIGIN,
+  origin: (origin, callback) => {
+    // Allow requests with no origin (mobile apps, Postman, etc.)
+    if (!origin) return callback(null, true);
+
+    // Allow Expo Go URLs (exp://)
+    if (origin.startsWith('exp://')) return callback(null, true);
+
+    // Allow configured origins
+    if (allowedOrigins.includes(origin) || allowedOrigins.includes('*')) {
+      return callback(null, true);
+    }
+
+    callback(new Error('Not allowed by CORS'));
+  },
   credentials: true,
 }));
 

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -9,6 +9,7 @@ interface EnvConfig {
   JWT_SECRET: string;
   JWT_EXPIRES_IN: string;
   CORS_ORIGIN: string;
+  ANTHROPIC_API_KEY: string;
 }
 
 const getEnvVar = (key: string, defaultValue?: string): string => {
@@ -22,10 +23,11 @@ const getEnvVar = (key: string, defaultValue?: string): string => {
 export const env: EnvConfig = {
   NODE_ENV: getEnvVar('NODE_ENV', 'development'),
   PORT: parseInt(getEnvVar('PORT', '3000'), 10),
-  MONGODB_URI: getEnvVar('MONGODB_URI', 'mongodb://localhost:27017/gen-workout'),
+  MONGODB_URI: getEnvVar('MONGODB_URI', 'mongodb://localhost:27017/fit-gpt'),
   JWT_SECRET: getEnvVar('JWT_SECRET', 'dev-secret-change-in-production'),
   JWT_EXPIRES_IN: getEnvVar('JWT_EXPIRES_IN', '7d'),
   CORS_ORIGIN: getEnvVar('CORS_ORIGIN', 'http://localhost:3000'),
+  ANTHROPIC_API_KEY: getEnvVar('ANTHROPIC_API_KEY'),
 };
 
 export const isDevelopment = env.NODE_ENV === 'development';

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,21 +1,28 @@
 {
   "expo": {
-    "name": "frontend",
-    "slug": "frontend",
+    "name": "FitGPT",
+    "slug": "fit-gpt",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
-    "scheme": "genworkout",
+    "scheme": "fitgpt",
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
+    "updates": {
+      "fallbackToCacheTimeout": 0,
+      "url": "https://u.expo.dev/your-project-id"
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.genworkout.app"
+      "bundleIdentifier": "com.fitgpt.app"
     },
     "android": {
       "adaptiveIcon": {
@@ -24,10 +31,16 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "package": "com.genworkout.app"
+      "package": "com.fitgpt.app"
     },
     "web": {
       "favicon": "./assets/favicon.png"
+    },
+    "extra": {
+      "eas": {
+        "projectId": "your-project-id-will-be-set-by-eas-cli"
+      },
+      "apiBaseUrl": "https://your-railway-url.railway.app/api"
     }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "expo-constants": "^18.0.10",
         "expo-haptics": "^15.0.7",
         "expo-status-bar": "~3.0.8",
+        "expo-updates": "^29.0.12",
         "react": "19.1.0",
         "react-hook-form": "^7.66.0",
         "react-native": "0.81.5",
@@ -5867,11 +5868,36 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-1.0.7.tgz",
+      "integrity": "sha512-Q/b1X0fM+3beqqvffok14pjxMF600NxopdSr9WJY61fF4xllcVnALS0kEudffp9ihMOfcb5xWYqzKj6jMqYDIw==",
+      "license": "MIT"
+    },
     "node_modules/expo-haptics": {
       "version": "15.0.7",
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-15.0.7.tgz",
       "integrity": "sha512-7flWsYPrwjJxZ8x82RiJtzsnk1Xp9ahnbd9PhCy3NnsemyMApoWIEUr4waPqFr80DtiLZfhD9VMLL1CKa8AImQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.8.tgz",
+      "integrity": "sha512-nA5PwU2uiUd+2nkDWf9e71AuFAtbrb330g/ecvuu52bmaXtN8J8oiilc9BDvAX0gg2fbtOaZdEdjBYopt1jdlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.8",
+        "expo-json-utils": "~0.15.0"
+      },
       "peerDependencies": {
         "expo": "*"
       }
@@ -5996,6 +6022,127 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-structured-headers": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-5.0.0.tgz",
+      "integrity": "sha512-RmrBtnSphk5REmZGV+lcdgdpxyzio5rJw8CXviHE6qH5pKQQ83fhMEcigvrkBdsn2Efw2EODp4Yxl1/fqMvOZw==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "29.0.12",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-29.0.12.tgz",
+      "integrity": "sha512-gE3bU6qi5g8Y1TtBzoeHac3utR0i1Wj1ufThh+zpDyFjFbegFm+gwvNLVCBagZUClYKk/4CKxh5ytnwZmPzH+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "0.0.5",
+        "@expo/plist": "^0.4.7",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "expo-eas-client": "~1.0.7",
+        "expo-manifests": "~1.0.8",
+        "expo-structured-headers": "~5.0.0",
+        "expo-updates-interface": "~2.0.0",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expo-updates/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/expo-updates/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expo-updates/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/expo/node_modules/@babel/code-frame": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "test": "jest",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "publish": "expo publish",
+    "update": "expo publish --release-channel production"
   },
   "dependencies": {
     "@gorhom/bottom-sheet": "^5.2.6",
@@ -24,6 +26,7 @@
     "expo-constants": "^18.0.10",
     "expo-haptics": "^15.0.7",
     "expo-status-bar": "~3.0.8",
+    "expo-updates": "^29.0.12",
     "react": "19.1.0",
     "react-hook-form": "^7.66.0",
     "react-native": "0.81.5",

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -1,13 +1,33 @@
 // Environment configuration
-// In Expo/React Native, you can access environment variables using process.env
-// Make sure to restart the bundler after changing environment variables
+// Using expo-constants for environment variables
+import Constants from 'expo-constants';
+
+const ENV = {
+  dev: {
+    apiBaseUrl: 'http://localhost:3000/api',
+  },
+  prod: {
+    apiBaseUrl: Constants.expoConfig?.extra?.apiBaseUrl || 'https://your-railway-url.railway.app/api',
+  },
+};
+
+const getEnvVars = () => {
+  // __DEV__ is set by React Native
+  // @ts-ignore - __DEV__ is a React Native global
+  if (typeof __DEV__ !== 'undefined' && __DEV__) {
+    return ENV.dev;
+  }
+  return ENV.prod;
+};
+
+const selectedEnv = getEnvVars();
 
 const config = {
   // API Configuration
-  apiBaseUrl: process.env.API_BASE_URL || 'http://localhost:3000/api',
+  apiBaseUrl: selectedEnv.apiBaseUrl,
 
   // App Configuration
-  appName: 'Gen Workout',
+  appName: 'FitGPT',
   appVersion: '1.0.0',
 
   // Feature Flags (can be extended)

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -7,7 +7,7 @@ import { RootNavigator } from './RootNavigator';
 
 // Deep linking configuration
 const linking: LinkingOptions<any> = {
-  prefixes: ['genworkout://', 'https://genworkout.app'],
+  prefixes: ['fitgpt://', 'https://fitgpt.app'],
   config: {
     screens: {
       // Auth screens


### PR DESCRIPTION
Backend changes:
- Add ANTHROPIC_API_KEY to environment configuration
- Update CORS to support Expo Go (exp:// URLs) and multiple origins
- Create production environment example (.env.production.example)
- Update package name to fit-gpt-backend
- Update MongoDB URI default to fit-gpt database

Frontend changes:
- Install expo-updates package for OTA updates
- Update app.json with FitGPT branding and OTA update configuration
- Configure environment-aware API URL handling (dev/prod)
- Add publishing scripts to package.json
- Update deep linking scheme to fitgpt://
- Update bundle identifiers to com.fitgpt.app

Deployment infrastructure:
- Add GitHub Actions workflow for auto-deploy to Railway
- Create comprehensive DEPLOYMENT.md with step-by-step setup guide

Branding consolidation:
- Rename from GenWorkout/gen-workout to FitGPT/fit-gpt throughout codebase