### PR TITLE
Migrate from expo-constants to Expo environment variables

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-API_BASE_URL=http://localhost:3000/api
+EXPO_PUBLIC_API_BASE_URL=http://localhost:3000/api

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# API Configuration
+# For local development, use localhost
+# For production testing on device, create .env.local with production URL
+EXPO_PUBLIC_API_BASE_URL=http://localhost:3000/api

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+EXPO_PUBLIC_API_BASE_URL=https://fit-gpt-backend-production.up.railway.app/api

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -37,7 +37,6 @@
       "favicon": "./assets/favicon.png"
     },
     "extra": {
-      "apiBaseUrl": "https://fit-gpt-backend-production.up.railway.app",
       "eas": {
         "projectId": "e16ab784-5462-4e69-abac-9ad255a323ba"
       }

--- a/frontend/src/constants/config.ts
+++ b/frontend/src/constants/config.ts
@@ -1,30 +1,13 @@
 // Environment configuration
-// Using expo-constants for environment variables
-import Constants from 'expo-constants';
-
-const ENV = {
-  dev: {
-    apiBaseUrl: 'http://localhost:3000/api',
-  },
-  prod: {
-    apiBaseUrl: Constants.expoConfig?.extra?.apiBaseUrl || 'https://your-railway-url.railway.app/api',
-  },
-};
-
-const getEnvVars = () => {
-  // __DEV__ is set by React Native
-  // @ts-ignore - __DEV__ is a React Native global
-  if (typeof __DEV__ !== 'undefined' && __DEV__) {
-    return ENV.dev;
-  }
-  return ENV.prod;
-};
-
-const selectedEnv = getEnvVars();
+// Using Expo's built-in environment variable support
+// Variables are loaded from .env, .env.production, or .env.local files
+// Use EXPO_PUBLIC_ prefix to make variables available at runtime
 
 const config = {
   // API Configuration
-  apiBaseUrl: selectedEnv.apiBaseUrl,
+  // Reads from EXPO_PUBLIC_API_BASE_URL in .env files
+  // Defaults to localhost for development if not set
+  apiBaseUrl: process.env.EXPO_PUBLIC_API_BASE_URL || 'http://localhost:3000/api',
 
   // App Configuration
   appName: 'FitGPT',


### PR DESCRIPTION
## Summary

Resolves #40

This PR migrates the frontend configuration from `expo-constants` to Expo's built-in environment variable support. This change enables developers to easily switch between development and production API endpoints by using `.env` files.

### Key Changes

- **Updated `.env`**: Changed `API_BASE_URL` to `EXPO_PUBLIC_API_BASE_URL` (required prefix for Expo)
- **Created `.env.production`**: Contains production API URL for production builds
- **Created `.env.example`**: Documents required environment variables
- **Simplified `config.ts`**: Removed expo-constants dependency and __DEV__ logic, now reads directly from `process.env.EXPO_PUBLIC_API_BASE_URL`
- **Cleaned up `app.json`**: Removed hardcoded `apiBaseUrl` from `extra` config

### Benefits

1. **Easy environment switching**: Developers can now create a `.env.local` file (gitignored) to test against the production backend while developing on their phone via Expo Go
2. **Standard approach**: Uses Expo's recommended environment variable pattern
3. **Simpler code**: Removed complex dev/prod switching logic
4. **Better separation**: Environment-specific configs are now in separate files

### Testing Instructions

1. **Default behavior** (unchanged): Running `expo start` will use localhost API from `.env`
2. **Testing prod on device**: Create `frontend/.env.local` with:
   ```
   EXPO_PUBLIC_API_BASE_URL=https://fit-gpt-backend-production.up.railway.app/api
   ```
   Then restart the dev server

### Migration Notes

- The `.env.local` file is already gitignored (pattern `.env*.local` exists in `.gitignore`)
- `expo-constants` package is still installed as it may be used by other Expo packages
- TypeScript compilation passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)