### PR TITLE
Add navigation between Login and Register screens

### DIFF
--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -8,14 +8,21 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FormInput } from '../../components/forms/FormInput';
 import { FormButton } from '../../components/forms/FormButton';
 import { useAuth } from '../../contexts/AuthContext';
 import { loginSchema, type LoginFormData } from '../../types/auth.validation';
+import type { AuthStackParamList } from '../../navigation/AuthNavigator';
+import config from '../../constants/config';
+
+type LoginScreenNavigationProp = StackNavigationProp<AuthStackParamList, 'Login'>;
 
 export const LoginScreen: React.FC = () => {
+  const navigation = useNavigation<LoginScreenNavigationProp>();
   const { login } = useAuth();
   const [apiError, setApiError] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
@@ -162,11 +169,7 @@ export const LoginScreen: React.FC = () => {
           <View style={styles.footer}>
             <Text style={styles.footerText}>Don't have an account? </Text>
             <TouchableOpacity
-              onPress={() => {
-                // TODO: Navigate to Register screen when navigator is set up
-                // navigation.navigate('Register');
-                console.log('Navigate to Register - navigator not yet implemented');
-              }}
+              onPress={() => navigation.navigate('Register')}
               testID="login-register-link"
             >
               <Text style={styles.footerLink}>Sign Up</Text>

--- a/frontend/src/screens/auth/RegisterScreen.tsx
+++ b/frontend/src/screens/auth/RegisterScreen.tsx
@@ -8,14 +8,20 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { StackNavigationProp } from '@react-navigation/stack';
 import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FormInput } from '../../components/forms/FormInput';
 import { FormButton } from '../../components/forms/FormButton';
 import { useAuth } from '../../contexts/AuthContext';
 import { registerSchema, type RegisterFormData } from '../../types/auth.validation';
+import type { AuthStackParamList } from '../../navigation/AuthNavigator';
+
+type RegisterScreenNavigationProp = StackNavigationProp<AuthStackParamList, 'Register'>;
 
 export const RegisterScreen: React.FC = () => {
+  const navigation = useNavigation<RegisterScreenNavigationProp>();
   const { register } = useAuth();
   const [apiError, setApiError] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
@@ -207,11 +213,7 @@ export const RegisterScreen: React.FC = () => {
           <View style={styles.footer}>
             <Text style={styles.footerText}>Already have an account? </Text>
             <TouchableOpacity
-              onPress={() => {
-                // TODO: Navigate to Login screen when navigator is set up
-                // navigation.navigate('Login');
-                console.log('Navigate to Login - navigator not yet implemented');
-              }}
+              onPress={() => navigation.navigate('Login')}
               testID="register-login-link"
             >
               <Text style={styles.footerLink}>Sign In</Text>


### PR DESCRIPTION
## Summary

- Implements navigation from LoginScreen to RegisterScreen when "Sign Up" is clicked
- Implements navigation from RegisterScreen to LoginScreen when "Sign In" is clicked
- Adds React Navigation hooks (`useNavigation`) and TypeScript types to both screens
- Removes placeholder console.log statements and TODO comments

## Changes

### LoginScreen (`frontend/src/screens/auth/LoginScreen.tsx`)
- Added `useNavigation` hook with proper TypeScript typing
- "Sign Up" link now calls `navigation.navigate('Register')`

### RegisterScreen (`frontend/src/screens/auth/RegisterScreen.tsx`)
- Added `useNavigation` hook with proper TypeScript typing
- "Sign In" link now calls `navigation.navigate('Login')`

## Test plan

Manual testing steps:
- [ ] Open app to Login screen
- [ ] Tap "Sign Up" link → should navigate to Register screen
- [ ] From Register screen, tap "Sign In" link → should navigate back to Login screen
- [ ] Fill out registration form with valid data and submit → should successfully register and navigate to main app
- [ ] Log out and verify navigation still works between Login/Register screens

## Notes

- No unit tests added (per FE-1 guideline: don't write tests for components)
- Type checking passes successfully
- Backend registration already functional and tested (verified auth.routes.test.ts)

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)