### PR TITLE
Fix LLM setting reps, weight, and duration in Set instances

### DIFF
--- a/backend/src/services/workoutParser/types.ts
+++ b/backend/src/services/workoutParser/types.ts
@@ -31,6 +31,32 @@ export interface ExerciseInstanceWithPlaceholder
 export interface SetInstanceWithoutId extends Omit<SetInstance, 'id'> {}
 
 /**
+ * LLM response for a set - excludes fields that should be filled during workout
+ * The LLM should not set reps, weight, or duration - these are filled by the user
+ */
+export interface SetInstanceFromLLM {
+  setNumber: number;
+  weightUnit: 'lbs' | 'kg';
+  rpe?: number | null;
+  notes?: string | null;
+}
+
+export interface ExerciseInstanceFromLLM
+  extends Omit<ExerciseInstanceWithPlaceholder, 'sets'> {
+  sets: SetInstanceFromLLM[];
+}
+
+export interface WorkoutBlockFromLLM
+  extends Omit<WorkoutBlockWithPlaceholders, 'exercises'> {
+  exercises: ExerciseInstanceFromLLM[];
+}
+
+export interface WorkoutFromLLM
+  extends Omit<WorkoutWithPlaceholders, 'blocks' | 'date' | 'lastModifiedTime'> {
+  blocks: WorkoutBlockFromLLM[];
+}
+
+/**
  * Stage 2 output: Workout structure with resolved exerciseIds
  * After Stage 2, exerciseName has been resolved to exerciseId
  */

--- a/backend/tests/integration/routes/workoutParser.test.ts
+++ b/backend/tests/integration/routes/workoutParser.test.ts
@@ -490,4 +490,37 @@ Mix everything together and bake at 350°F for 12 minutes.
     expect(retrievedWorkout.blocks).toHaveLength(1);
     expect(retrievedWorkout.blocks[0].exercises).toHaveLength(2);
   }, 60000);
+
+  it('should set reps, weight, and duration to null for all sets', async () => {
+    const workoutText = `
+## Test Workout
+
+**Main Lifts**
+- Push-ups: 3x10
+- Plank: 2x45 sec
+- Back Squat: 4x8
+    `;
+
+    const response = await request(app)
+      .post('/api/workouts/parse')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        text: workoutText,
+      })
+      .expect(200);
+
+    const workout = response.body.data;
+
+    // Verify all sets have reps, weight, and duration set to null
+    workout.blocks.forEach((block: any) => {
+      block.exercises.forEach((exercise: any) => {
+        exercise.sets.forEach((set: any) => {
+          // All these fields should be null, NOT numbers or undefined
+          expect(set.reps).toBeNull();
+          expect(set.weight).toBeNull();
+          expect(set.duration).toBeNull();
+        });
+      });
+    });
+  }, 60000);
 });


### PR DESCRIPTION
## Summary
- Removed `reps`, `weight`, and `duration` fields from LLM prompt and examples
- Created new TypeScript interfaces for LLM responses that exclude user-filled fields
- Added post-processing to explicitly set these fields to null after receiving LLM response
- Added integration test to verify all sets have these fields set to null

## Problem
The LLM was occasionally setting values for `reps`, `weight`, and `duration` fields in Set instances, despite being instructed to set them to null. This was especially noticeable for `duration` in time-based exercises where the example showed `duration: 300`.

## Solution
Instead of asking the LLM to set these fields to null (which it sometimes ignored), we:
1. Remove these fields entirely from the expected JSON structure in the prompt
2. Use new TypeScript interfaces (`SetInstanceFromLLM`, `ExerciseInstanceFromLLM`, `WorkoutBlockFromLLM`, `WorkoutFromLLM`) that don't include these fields
3. Programmatically add these fields as null in post-processing

This ensures these fields are always null, regardless of what the LLM outputs.

## Test plan
- [x] All existing tests pass (9/9 workoutParser tests passing)
- [x] New test verifies all sets have `reps: null`, `weight: null`, `duration: null`
- [x] TypeScript type checking passes

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)