### PR TITLE
Optimize updateSet

### DIFF
--- a/backend/src/services/workout.service.ts
+++ b/backend/src/services/workout.service.ts
@@ -569,14 +569,7 @@ export const updateSet = async (
 ): Promise<WorkoutType> => {
   const repo = getWorkoutRepository();
 
-  // Find workout ID containing this set
-  const workoutId = await repo.findWorkoutIdBySetId(setId);
-
-  if (!workoutId) {
-    throw new AppError('Set not found', 404);
-  }
-
-  // Update the set
+  // Update the set (this also returns the workout ID)
   const updates = {
     reps: setData.reps,
     weight: setData.weight,
@@ -586,21 +579,21 @@ export const updateSet = async (
     notes: setData.notes,
   };
 
-  const updatedSet = await repo.updateSet(setId, updates);
+  const result = await repo.updateSet(setId, updates);
 
-  if (!updatedSet) {
+  if (!result) {
     throw new AppError('Set not found', 404);
   }
 
   const now = new Date().toISOString();
 
   // Update workout's lastModifiedTime
-  await repo.update(workoutId, {
+  await repo.update(result.workoutId, {
     lastModifiedTime: now,
   });
 
   // Return updated workout
-  const updatedWorkout = await repo.findById(workoutId);
+  const updatedWorkout = await repo.findById(result.workoutId);
 
   if (!updatedWorkout) {
     throw new AppError('Workout not found after set update', 500);

--- a/backend/tests/unit/repositories/WorkoutRepository.test.ts
+++ b/backend/tests/unit/repositories/WorkoutRepository.test.ts
@@ -590,21 +590,23 @@ describe('WorkoutRepository', () => {
       });
 
       const setId = workout.blocks[0].exercises[0].sets[0].id;
-      const updated = await workoutRepository.updateSet(setId, {
+      const result = await workoutRepository.updateSet(setId, {
         reps: 12,
         weight: 120,
       });
 
-      expect(updated?.reps).toBe(12);
-      expect(updated?.weight).toBe(120);
+      expect(result).not.toBeNull();
+      expect(result?.set.reps).toBe(12);
+      expect(result?.set.weight).toBe(120);
+      expect(result?.workoutId).toBe(workout.id);
     });
 
     it('should return null for non-existent set', async () => {
-      const updated = await workoutRepository.updateSet('999999', {
+      const result = await workoutRepository.updateSet('999999', {
         reps: 12,
       });
 
-      expect(updated).toBeNull();
+      expect(result).toBeNull();
     });
   });
 

--- a/backend/tests/unit/services/workout.service.test.ts
+++ b/backend/tests/unit/services/workout.service.test.ts
@@ -453,8 +453,7 @@ describe('Workout Service', () => {
         ],
       };
 
-      mockWorkoutRepo.findWorkoutIdBySetId = jest.fn().mockResolvedValue(mockWorkoutId);
-      mockWorkoutRepo.updateSet = jest.fn().mockResolvedValue(mockSet);
+      mockWorkoutRepo.updateSet = jest.fn().mockResolvedValue({ set: mockSet, workoutId: mockWorkoutId });
       mockWorkoutRepo.update = jest.fn().mockResolvedValue(mockWorkout);
       mockWorkoutRepo.findById = jest.fn().mockResolvedValue(mockWorkout);
 
@@ -497,8 +496,7 @@ describe('Workout Service', () => {
         ],
       };
 
-      mockWorkoutRepo.findWorkoutIdBySetId = jest.fn().mockResolvedValue(mockWorkoutId);
-      mockWorkoutRepo.updateSet = jest.fn().mockResolvedValue(mockSet);
+      mockWorkoutRepo.updateSet = jest.fn().mockResolvedValue({ set: mockSet, workoutId: mockWorkoutId });
       mockWorkoutRepo.update = jest.fn().mockResolvedValue(mockWorkout);
       mockWorkoutRepo.findById = jest.fn().mockResolvedValue(mockWorkout);
 


### PR DESCRIPTION
Optimize the updateSet function by consolidating database operations:
- Modified WorkoutRepository.updateSet to return both the updated set and its workout ID in a single operation
- Eliminated the separate findWorkoutIdBySetId call in workout.service
- Reduced database queries from 4 to 3 (updateSet, update workout timestamp, fetch workout)
- Updated tests to match the new return signature

This makes the code more efficient and easier to maintain while preserving the same API contract.