### PR TITLE
Fix duplicate key error in seedExercisesFromWrkout by deduplicating tags

### DIFF
--- a/backend/src/scripts/seedExercisesFromWrkout.ts
+++ b/backend/src/scripts/seedExercisesFromWrkout.ts
@@ -44,6 +44,7 @@ export function generateSlug(name: string): string {
 /**
  * Flatten all metadata fields from wrkout exercise into tags array
  * Excludes instructions and name
+ * Deduplicates tags (case-insensitive)
  */
 export function flattenToTags(wrkoutExercise: WrkoutExercise): string[] {
   const tags: string[] = [];
@@ -66,7 +67,18 @@ export function flattenToTags(wrkoutExercise: WrkoutExercise): string[] {
   }
 
   // Filter out any null, undefined, or empty strings
-  return tags.filter((tag) => tag && tag.trim() !== '');
+  const filteredTags = tags.filter((tag) => tag && tag.trim() !== '');
+
+  // Deduplicate tags (case-insensitive)
+  const lowerCaseMap = new Map<string, string>();
+  for (const tag of filteredTags) {
+    const lowerCase = tag.toLowerCase();
+    if (!lowerCaseMap.has(lowerCase)) {
+      lowerCaseMap.set(lowerCase, tag);
+    }
+  }
+
+  return Array.from(lowerCaseMap.values());
 }
 
 /**

--- a/backend/tests/integration/scripts/seedExercisesFromWrkout.test.ts
+++ b/backend/tests/integration/scripts/seedExercisesFromWrkout.test.ts
@@ -1,0 +1,107 @@
+import { ExerciseRepository } from '../../../src/repositories/ExerciseRepository';
+import {
+  fetchExerciseList,
+  fetchExerciseData,
+  transformWrkoutExercise,
+} from '../../../src/scripts/seedExercisesFromWrkout';
+import { upsertExercises } from '../../../src/scripts/seedExercises';
+import * as testDb from '../../utils/testDb';
+
+/**
+ * Integration tests for seedExercisesFromWrkout script
+ * Tests the full workflow of fetching exercises from wrkout API and inserting them
+ */
+describe('seedExercisesFromWrkout integration', () => {
+  let exerciseRepo: ExerciseRepository;
+
+  // Setup: Connect to test database before all tests
+  beforeAll(async () => {
+    await testDb.connect();
+    const db = testDb.getTestDb();
+    exerciseRepo = new ExerciseRepository(db);
+  });
+
+  // Cleanup: Clear database after each test
+  afterEach(async () => {
+    await testDb.clearDatabase();
+  });
+
+  // Teardown: Close database connection after all tests
+  afterAll(async () => {
+    await testDb.closeDatabase();
+  });
+
+  it('should fetch, transform, and upsert first 50 exercises from wrkout API', async () => {
+    // Fetch exercise list from GitHub API
+    const exerciseNames = await fetchExerciseList();
+    expect(exerciseNames.length).toBeGreaterThan(0);
+
+    // Take first 50 exercises
+    const first50 = exerciseNames.slice(0, 50);
+    expect(first50.length).toBe(50);
+
+    // Fetch and transform exercises
+    const exercises = [];
+    for (const exerciseName of first50) {
+      try {
+        const wrkoutExercise = await fetchExerciseData(exerciseName);
+        const transformed = transformWrkoutExercise(wrkoutExercise);
+        exercises.push(transformed);
+      } catch (error) {
+        console.error(`Error fetching exercise ${exerciseName}:`, error);
+      }
+    }
+
+    // Should have successfully fetched most exercises
+    expect(exercises.length).toBeGreaterThan(40);
+
+    // Upsert exercises into database (this should not fail with duplicate key error)
+    await upsertExercises(exercises);
+
+    // Verify exercises were inserted
+    const allExercises = await exerciseRepo.findAll();
+    expect(allExercises.length).toBe(exercises.length);
+
+    // Verify each exercise has unique tags (no duplicates in exercise_tags table)
+    for (const exercise of allExercises) {
+      const tags = exercise.tags || [];
+      const uniqueTags = [...new Set(tags)];
+      expect(tags.length).toBe(uniqueTags.length);
+    }
+  }, 60000); // Increase timeout to 60 seconds for API calls
+
+  it('should handle upserting the same exercises twice without errors', async () => {
+    // Fetch exercise list from GitHub API
+    const exerciseNames = await fetchExerciseList();
+
+    // Take first 10 exercises
+    const first10 = exerciseNames.slice(0, 10);
+
+    // Fetch and transform exercises
+    const exercises = [];
+    for (const exerciseName of first10) {
+      try {
+        const wrkoutExercise = await fetchExerciseData(exerciseName);
+        const transformed = transformWrkoutExercise(wrkoutExercise);
+        exercises.push(transformed);
+      } catch (error) {
+        console.error(`Error fetching exercise ${exerciseName}:`, error);
+      }
+    }
+
+    // Upsert exercises twice
+    await upsertExercises(exercises);
+    await upsertExercises(exercises);
+
+    // Verify only one copy of each exercise exists
+    const allExercises = await exerciseRepo.findAll();
+    expect(allExercises.length).toBe(exercises.length);
+
+    // Verify each exercise has unique tags
+    for (const exercise of allExercises) {
+      const tags = exercise.tags || [];
+      const uniqueTags = [...new Set(tags)];
+      expect(tags.length).toBe(uniqueTags.length);
+    }
+  }, 30000); // Increase timeout to 30 seconds for API calls
+});

--- a/backend/tests/unit/scripts/seedExercisesFromWrkout.test.ts
+++ b/backend/tests/unit/scripts/seedExercisesFromWrkout.test.ts
@@ -150,6 +150,53 @@ describe('seedExercisesFromWrkout', () => {
       expect(tags).not.toContain(null);
       expect(tags).not.toContain(undefined);
     });
+
+    it('should deduplicate tags when same value appears in multiple fields', () => {
+      const wrkoutExercise = {
+        name: 'Test Exercise',
+        force: 'pull',
+        level: 'beginner',
+        mechanic: 'isolation',
+        equipment: 'quadriceps',
+        primaryMuscles: ['quadriceps', 'glutes'],
+        secondaryMuscles: ['hamstrings', 'quadriceps'],
+        instructions: [],
+        category: 'strength',
+      };
+
+      const tags = flattenToTags(wrkoutExercise);
+
+      // Count occurrences of 'quadriceps'
+      const quadricepsCount = tags.filter((tag) => tag === 'quadriceps').length;
+
+      // Should only appear once
+      expect(quadricepsCount).toBe(1);
+      expect(tags).toContain('quadriceps');
+      expect(tags).toContain('glutes');
+      expect(tags).toContain('hamstrings');
+    });
+
+    it('should handle case-insensitive deduplication', () => {
+      const wrkoutExercise = {
+        name: 'Test Exercise',
+        force: 'Pull',
+        level: 'beginner',
+        mechanic: 'isolation',
+        equipment: 'dumbbell',
+        primaryMuscles: ['pull'],
+        secondaryMuscles: [],
+        instructions: [],
+        category: 'strength',
+      };
+
+      const tags = flattenToTags(wrkoutExercise);
+
+      // Count occurrences of 'pull' or 'Pull'
+      const pullCount = tags.filter((tag) => tag.toLowerCase() === 'pull').length;
+
+      // Should only appear once (case-insensitive)
+      expect(pullCount).toBe(1);
+    });
   });
 
   describe('transformWrkoutExercise', () => {


### PR DESCRIPTION
## Summary
- Fixed unique constraint violation in `seedExercisesFromWrkout` script when duplicate tags appear in exercise metadata
- Added unit tests to verify tag deduplication logic (case-insensitive)
- Added integration test that validates seeding first 50 exercises from wrkout API
- Updated `flattenToTags()` function to deduplicate tags using a Map with lowercase keys

## Problem
The `seed:exercises:wrkout` script was failing with error:
```
duplicate key value violates unique constraint "exercise_tags_exercise_id_tag_unique"
```

This occurred when the same tag value appeared in multiple metadata fields (e.g., "quadriceps" in both `equipment` and `primaryMuscles`), causing duplicate entries in the `exercise_tags` table.

## Solution
Modified `flattenToTags()` in `seedExercisesFromWrkout.ts` to deduplicate tags case-insensitively while preserving the original casing of the first occurrence.

## Test Plan
- ✅ Unit tests verify deduplication of exact duplicates
- ✅ Unit tests verify case-insensitive deduplication
- ✅ Integration test validates seeding 50 exercises from wrkout API without errors
- ✅ Integration test validates upserting same exercises twice works correctly
- ✅ All existing tests still pass
- ✅ Type checks pass

## Related Issue
Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)