### PR TITLE
Remove Mock Workout from exercise lists

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -16,12 +16,13 @@ module.exports = {
       {
         tsconfig: {
           jsx: 'react',
+          skipLibCheck: true,
         },
       },
     ],
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|@react-navigation|@tanstack|expo|expo-.*)/)',
+    'node_modules/(?!(react-native|@react-native|@react-navigation|@tanstack|expo|expo-.*|react-native-calendars)/)',
   ],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {

--- a/frontend/src/screens/CalendarScreen.tsx
+++ b/frontend/src/screens/CalendarScreen.tsx
@@ -42,13 +42,6 @@ export const CalendarScreen: React.FC = () => {
     queryFn: () => getWorkoutsCalendar(dateRange.startDate, dateRange.endDate),
   });
 
-  // Create mock workout for testing
-  const mockWorkout: WorkoutSummary = {
-    id: 'mock-workout-123',
-    name: 'Mock Workout',
-    date: selectedDate || new Date().toISOString().split('T')[0],
-  };
-
   // Group workouts by date
   const workoutsByDate = useMemo(() => {
     const grouped: { [date: string]: WorkoutSummary[] } = {};
@@ -138,12 +131,10 @@ export const CalendarScreen: React.FC = () => {
     });
   };
 
-  // Get workouts for selected date (including mock workout for testing)
+  // Get workouts for selected date
   const selectedDateWorkouts = useMemo(() => {
-    const workoutsForDate = workoutsByDate[selectedDate] || [];
-    // Add mock workout to every selected date for testing
-    return [mockWorkout, ...workoutsForDate];
-  }, [selectedDate, workoutsByDate, mockWorkout]);
+    return workoutsByDate[selectedDate] || [];
+  }, [selectedDate, workoutsByDate]);
 
   if (isLoading) {
     return (

--- a/frontend/src/screens/__tests__/CalendarScreen.test.tsx
+++ b/frontend/src/screens/__tests__/CalendarScreen.test.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { CalendarScreen } from '../CalendarScreen';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigation } from '@react-navigation/native';
+import type { WorkoutSummary } from '../../types/workout.types';
+
+// Mock dependencies
+jest.mock('@tanstack/react-query');
+jest.mock('@react-navigation/native');
+jest.mock('react-native-calendars', () => ({
+  Calendar: jest.fn(() => {
+    const { View } = require('react-native');
+    return <View testID="calendar" />;
+  }),
+}));
+jest.mock('../../components/workout/WorkoutListModal', () => ({
+  WorkoutListModal: jest.fn(({ workouts }: { workouts: WorkoutSummary[] }) => {
+    const { Text, View } = require('react-native');
+    return (
+      <View testID="workout-list-modal">
+        <Text testID="workout-count">{workouts.length}</Text>
+        {workouts.map((w) => (
+          <Text key={w.id} testID={`workout-${w.id}`}>
+            {w.name}
+          </Text>
+        ))}
+      </View>
+    );
+  }),
+}));
+
+const mockedUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+const mockedUseNavigation = useNavigation as jest.MockedFunction<typeof useNavigation>;
+
+describe('CalendarScreen', () => {
+  const mockNavigation = {
+    navigate: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseNavigation.mockReturnValue(mockNavigation as any);
+  });
+
+  describe('Workout Display', () => {
+    it('should not include mock workout in workout list', () => {
+      // Arrange
+      const mockWorkouts: WorkoutSummary[] = [
+        {
+          id: 'real-workout-1',
+          name: 'Morning Workout',
+          date: '2025-11-15',
+        },
+        {
+          id: 'real-workout-2',
+          name: 'Evening Workout',
+          date: '2025-11-15',
+        },
+      ];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert - should not display mock workout
+      expect(screen.queryByText('Mock Workout')).toBeNull();
+      expect(screen.queryByTestId('workout-mock-workout-123')).toBeNull();
+    });
+
+    it('should pass only real workouts to WorkoutListModal', () => {
+      // Arrange
+      const mockWorkouts: WorkoutSummary[] = [
+        {
+          id: 'workout-1',
+          name: 'Leg Day',
+          date: '2025-11-20',
+        },
+        {
+          id: 'workout-2',
+          name: 'Arm Day',
+          date: '2025-11-20',
+        },
+      ];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert - modal should not receive mock workout with id 'mock-workout-123'
+      expect(screen.queryByTestId('workout-mock-workout-123')).toBeNull();
+    });
+  });
+
+  describe('Empty Date Selection', () => {
+    it('should show no workouts when selecting date with no workouts', () => {
+      // Arrange
+      const mockWorkouts: WorkoutSummary[] = [];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert - should not show mock workout
+      expect(screen.queryByTestId('workout-mock-workout-123')).toBeNull();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('should show loading indicator when fetching workouts', () => {
+      // Arrange
+      mockedUseQuery.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert
+      expect(screen.getByText('Loading calendar...')).toBeTruthy();
+    });
+  });
+
+  describe('Error State', () => {
+    it('should display error message when fetch fails', () => {
+      // Arrange
+      const mockError = new Error('Network error');
+      mockedUseQuery.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: mockError,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert
+      expect(screen.getByText('Failed to load workouts')).toBeTruthy();
+      expect(screen.getByText('Network error')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
- Remove mock workout constant that was being added for testing
- Update selectedDateWorkouts to return only real workouts from API
- Add comprehensive tests for CalendarScreen to verify no mock workouts
- Update jest config to properly handle react-native-calendars transformations

Fixes #78