### PR TITLE
Configure Jest to report only failures

### DIFF
--- a/backend/jest.config.integration.js
+++ b/backend/jest.config.integration.js
@@ -18,6 +18,8 @@ module.exports = {
   setupFiles: ['<rootDir>/tests/setup.ts'], // Set NODE_ENV=test before tests run
   globalSetup: '<rootDir>/tests/globalSetup.ts', // Start PostgreSQL container before all tests
   globalTeardown: '<rootDir>/tests/globalTeardown.ts', // Stop PostgreSQL container after all tests
+  silent: true, // Suppress console output during tests
+  verbose: false, // Only show summary, not individual tests (unless they fail)
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -15,6 +15,8 @@ module.exports = {
   setupFiles: ['<rootDir>/tests/setup.ts'], // Set NODE_ENV=test before tests run
   globalSetup: '<rootDir>/tests/globalSetup.ts', // Start PostgreSQL container before all tests
   globalTeardown: '<rootDir>/tests/globalTeardown.ts', // Stop PostgreSQL container after all tests
+  silent: true, // Suppress console output during tests
+  verbose: false, // Only show summary, not individual tests (unless they fail)
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/backend/jest.config.unit.js
+++ b/backend/jest.config.unit.js
@@ -16,6 +16,8 @@ module.exports = {
   testTimeout: 10000, // 10 second timeout for unit tests
   setupFiles: ['<rootDir>/tests/setup.ts'], // Set NODE_ENV=test before tests run
   // No globalSetup/globalTeardown - unit tests don't need database
+  silent: true, // Suppress console output during tests
+  verbose: false, // Only show summary, not individual tests (unless they fail)
   transform: {
     '^.+\\.ts$': [
       'ts-jest',

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -10,6 +10,8 @@ module.exports = {
     '!src/**/__tests__/**',
   ],
   testPathIgnorePatterns: ['/node_modules/'],
+  silent: true, // Suppress console output during tests
+  verbose: false, // Only show summary, not individual tests (unless they fail)
   transform: {
     '^.+\\.tsx?$': [
       'ts-jest',


### PR DESCRIPTION
Add silent: true and verbose: false to all Jest configurations to reduce noise during test runs. Tests will now only display summary information and detailed logs for failures, making it easier to spot issues.

Changes:
- backend/jest.config.js: Add silent and verbose settings
- backend/jest.config.unit.js: Add silent and verbose settings
- backend/jest.config.integration.js: Add silent and verbose settings
- frontend/jest.config.js: Add silent and verbose settings