### PR TITLE
Refactor repeated test mocks into shared utility

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -152,7 +152,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2203,7 +2202,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2421,7 +2419,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2622,7 +2619,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3382,7 +3378,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4431,7 +4426,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5866,7 +5860,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7589,7 +7582,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9191,7 +9183,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9291,7 +9282,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9709,7 +9699,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/tests/unit/middleware/auth.test.ts
+++ b/backend/tests/unit/middleware/auth.test.ts
@@ -5,6 +5,11 @@ import { AppError } from '../../../src/middleware/errorHandler';
 import { env } from '../../../src/config/env';
 import { generateToken } from '../../../src/services/auth.service';
 import { AuthenticatedRequest } from '../../../src/types';
+import {
+  createMockExpressRequest,
+  createMockExpressResponse,
+  createMockNextFunction,
+} from '../../utils/mocks';
 
 describe('Auth Middleware - Unit Tests', () => {
   let mockRequest: Partial<AuthenticatedRequest>;
@@ -13,11 +18,9 @@ describe('Auth Middleware - Unit Tests', () => {
 
   beforeEach(() => {
     // Create fresh mocks for each test
-    mockRequest = {
-      headers: {},
-    };
-    mockResponse = {};
-    mockNext = jest.fn();
+    mockRequest = createMockExpressRequest();
+    mockResponse = createMockExpressResponse();
+    mockNext = createMockNextFunction();
   });
 
   describe('Valid Token Cases', () => {
@@ -339,7 +342,7 @@ describe('Auth Middleware - Unit Tests', () => {
 
       userIds.forEach((userId) => {
         // Reset mocks
-        mockNext = jest.fn();
+        mockNext = createMockNextFunction();
         const token = generateToken(userId);
         mockRequest.headers = {
           authorization: `Bearer ${token}`,

--- a/backend/tests/unit/services/exerciseSearch.service.test.ts
+++ b/backend/tests/unit/services/exerciseSearch.service.test.ts
@@ -1,48 +1,38 @@
 import { createExerciseSearchService, type ExerciseSearchService } from '../../../src/services/exerciseSearch.service';
 import { ExerciseRepository } from '../../../src/repositories/ExerciseRepository';
 import { Exercise as ExerciseType } from '../../../src/types';
+import { createMockExerciseRepository, createMockExercise } from '../../utils/mocks';
 
 describe('ExerciseSearchService - Pure Function Tests', () => {
   let service: ExerciseSearchService;
   let mockRepository: jest.Mocked<ExerciseRepository>;
 
-  const mockBarbellBench: ExerciseType = {
+  const mockBarbellBench: ExerciseType = createMockExercise({
     id: '1',
     name: 'Barbell Bench Press',
     slug: 'barbell-bench-press',
     tags: ['chest', 'push', 'barbell'],
-  };
+  });
 
-  const mockDumbbellBench: ExerciseType = {
+  const mockDumbbellBench: ExerciseType = createMockExercise({
     id: '2',
     name: 'Dumbbell Bench Press',
     slug: 'dumbbell-bench-press',
     tags: ['chest', 'push', 'dumbbell'],
-  };
+  });
 
-  const mockCloseGripBarbellBench: ExerciseType = {
+  const mockCloseGripBarbellBench: ExerciseType = createMockExercise({
     id: '5',
     name: 'Close-Grip Barbell Bench Press',
     slug: 'close-grip-barbell-bench-press',
     tags: ['chest', 'triceps', 'push', 'barbell'],
-  };
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
 
     // Create mock repository (not used in pure function tests, but needed for service creation)
-    mockRepository = {
-      searchByName: jest.fn(),
-      create: jest.fn(),
-      findById: jest.fn(),
-      findBySlug: jest.fn(),
-      findAll: jest.fn(),
-      filter: jest.fn(),
-      update: jest.fn(),
-      delete: jest.fn(),
-      existsByName: jest.fn(),
-      findByTag: jest.fn(),
-    } as any;
+    mockRepository = createMockExerciseRepository();
 
     service = createExerciseSearchService(mockRepository);
   });

--- a/backend/tests/unit/services/workoutValidator.test.ts
+++ b/backend/tests/unit/services/workoutValidator.test.ts
@@ -1,10 +1,6 @@
 import { createWorkoutValidator, type WorkoutValidator } from '../../../src/services/workoutParser/workoutValidator';
 import { LLMService } from '../../../src/services/llm.service';
-
-// Mock the LLMService
-jest.mock('../../../src/services/llm.service');
-
-const MockedLLMService = LLMService as jest.MockedClass<typeof LLMService>;
+import { createMockLLMService } from '../../utils/mocks';
 
 describe('WorkoutValidator', () => {
   let validator: WorkoutValidator;
@@ -12,7 +8,7 @@ describe('WorkoutValidator', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockLLMService = new MockedLLMService() as jest.Mocked<LLMService>;
+    mockLLMService = createMockLLMService();
     validator = createWorkoutValidator(mockLLMService);
   });
 

--- a/backend/tests/utils/mocks.ts
+++ b/backend/tests/utils/mocks.ts
@@ -1,5 +1,12 @@
+import { Request, Response, NextFunction } from 'express';
 import { type EmbeddingService } from '../../src/services/embedding.service';
 import { type ExerciseCacheService } from '../../src/services/exerciseCache.service';
+import { type ExerciseRepository } from '../../src/repositories/ExerciseRepository';
+import { type UserRepository } from '../../src/repositories/UserRepository';
+import { type WorkoutRepository } from '../../src/repositories/WorkoutRepository';
+import { type LLMService } from '../../src/services/llm.service';
+import { Exercise as ExerciseType, User } from '../../src/types';
+import { AuthenticatedRequest } from '../../src/types';
 
 /**
  * Create a mock embedding service for unit tests
@@ -41,4 +48,126 @@ export function createMockExerciseCacheService(): jest.Mocked<ExerciseCacheServi
 export function getMockEmbeddingString(): string {
   const mockEmbedding = new Array(1536).fill(0);
   return `[${mockEmbedding.join(',')}]`;
+}
+
+/**
+ * Create a mock Express Request for middleware testing
+ */
+export function createMockExpressRequest(overrides?: Partial<AuthenticatedRequest>): Partial<AuthenticatedRequest> {
+  return {
+    headers: {},
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock Express Response for middleware testing
+ */
+export function createMockExpressResponse(): Partial<Response> {
+  return {};
+}
+
+/**
+ * Create a mock Express NextFunction for middleware testing
+ */
+export function createMockNextFunction(): NextFunction {
+  return jest.fn();
+}
+
+/**
+ * Create a mock ExerciseRepository for unit tests
+ */
+export function createMockExerciseRepository(): jest.Mocked<ExerciseRepository> {
+  return {
+    searchByName: jest.fn(),
+    create: jest.fn(),
+    findById: jest.fn(),
+    findBySlug: jest.fn(),
+    findAll: jest.fn(),
+    filter: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    existsByName: jest.fn(),
+    existsBySlug: jest.fn(),
+    existsById: jest.fn(),
+    findByTag: jest.fn(),
+    checkDuplicateName: jest.fn(),
+  } as any;
+}
+
+/**
+ * Create a mock UserRepository for unit tests
+ */
+export function createMockUserRepository(): jest.Mocked<UserRepository> {
+  return {
+    create: jest.fn(),
+    findById: jest.fn(),
+    findByEmail: jest.fn(),
+    findByIdWithPassword: jest.fn(),
+    findByEmailWithPassword: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    existsByEmail: jest.fn(),
+  } as any;
+}
+
+/**
+ * Create a mock WorkoutRepository for unit tests
+ */
+export function createMockWorkoutRepository(): jest.Mocked<WorkoutRepository> {
+  return {
+    create: jest.fn(),
+    findById: jest.fn(),
+    findByUserId: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  } as any;
+}
+
+/**
+ * Create a mock LLMService for unit tests
+ */
+export function createMockLLMService(): jest.Mocked<LLMService> {
+  return {
+    call: jest.fn(),
+  } as any;
+}
+
+/**
+ * Create a mock Exercise for unit tests
+ */
+export function createMockExercise(overrides?: Partial<ExerciseType>): ExerciseType {
+  return {
+    id: '1',
+    name: 'Mock Exercise',
+    slug: 'mock-exercise',
+    tags: ['test'],
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock User for unit tests
+ */
+export function createMockUser(overrides?: Partial<User>): User {
+  return {
+    id: '1',
+    email: 'test@example.com',
+    name: 'Test User',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+/**
+ * Create mock user data for registration/login
+ */
+export function createMockUserData(overrides?: { email?: string; password?: string; name?: string }) {
+  return {
+    email: 'test@example.com',
+    password: 'password123',
+    name: 'Test User',
+    ...overrides,
+  };
 }


### PR DESCRIPTION
Extract repeated mock patterns into backend/tests/utils/mocks.ts:
- Add createMockExpressRequest/Response/NextFunction for middleware tests
- Add createMockExerciseRepository/UserRepository/WorkoutRepository
- Add createMockLLMService for LLM service mocking
- Add createMockExercise/User/UserData for test fixtures

Update test files to use centralized mocks:
- tests/unit/middleware/auth.test.ts
- tests/unit/services/exerciseSearch.service.test.ts
- tests/unit/services/workoutValidator.test.ts

Benefits:
- DRY principle - single source of truth for mocks
- Improved maintainability - update mocks in one place
- Better consistency across tests
- Type safety with properly typed mock factories

All 148 unit tests passing after refactoring.