### PR TITLE
Add request body size limits to parser

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -152,7 +152,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2203,7 +2202,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2421,7 +2419,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2622,7 +2619,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3382,7 +3378,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4431,7 +4426,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5866,7 +5860,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7589,7 +7582,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9191,7 +9183,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9291,7 +9282,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9709,7 +9699,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/backend/src/createApp.ts
+++ b/backend/src/createApp.ts
@@ -70,9 +70,9 @@ export function createApp(db: Kysely<Database>, redisClient?: Redis | null): App
     })
   );
 
-  // Body parsing middleware
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
+  // Body parsing middleware with size limits to prevent DoS attacks (VULN-007)
+  app.use(express.json({ limit: '1mb' }));
+  app.use(express.urlencoded({ extended: true, limit: '1mb' }));
 
   // Logging middleware
   if (isDevelopment) {

--- a/backend/tests/integration/createApp.test.ts
+++ b/backend/tests/integration/createApp.test.ts
@@ -69,4 +69,79 @@ describe('createApp Factory', () => {
     expect(userInDb).toBeDefined();
     expect(userInDb?.name).toBe('Test User');
   });
+
+  describe('Body Size Limits (VULN-007)', () => {
+    it('should accept JSON payloads under 1MB', async () => {
+      const db = testContainer.getDb();
+      const app = createApp(db);
+
+      // Create a payload just under 1MB (approximately 900KB)
+      const smallPayload = {
+        email: 'test@example.com',
+        password: 'password123',
+        name: 'Test User',
+        // Add some padding data to make it substantial but under 1MB
+        data: 'x'.repeat(900 * 1024),
+      };
+
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send(smallPayload);
+
+      // Should not get 413 (Payload Too Large)
+      expect(response.status).not.toBe(413);
+    });
+
+    it('should reject JSON payloads over 1MB with 413', async () => {
+      const db = testContainer.getDb();
+      const app = createApp(db);
+
+      // Create a payload over 1MB (approximately 2MB)
+      const largePayload = {
+        email: 'test@example.com',
+        password: 'password123',
+        name: 'Test User',
+        data: 'x'.repeat(2 * 1024 * 1024),
+      };
+
+      const response = await request(app)
+        .post('/api/auth/register')
+        .send(largePayload);
+
+      // Should get 413 (Payload Too Large)
+      expect(response.status).toBe(413);
+    });
+
+    it('should accept URL-encoded payloads under 1MB', async () => {
+      const db = testContainer.getDb();
+      const app = createApp(db);
+
+      // Create a URL-encoded payload under 1MB
+      const smallData = 'x'.repeat(900 * 1024);
+
+      const response = await request(app)
+        .post('/api/auth/register')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send(`email=test@example.com&password=password123&name=Test&data=${smallData}`);
+
+      // Should not get 413 (Payload Too Large)
+      expect(response.status).not.toBe(413);
+    });
+
+    it('should reject URL-encoded payloads over 1MB with 413', async () => {
+      const db = testContainer.getDb();
+      const app = createApp(db);
+
+      // Create a URL-encoded payload over 1MB (approximately 2MB)
+      const largeData = 'x'.repeat(2 * 1024 * 1024);
+
+      const response = await request(app)
+        .post('/api/auth/register')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send(`email=test@example.com&password=password123&name=Test&data=${largeData}`);
+
+      // Should get 413 (Payload Too Large)
+      expect(response.status).toBe(413);
+    });
+  });
 });


### PR DESCRIPTION
- Add 1mb size limits to express.json() and express.urlencoded() middleware
- Prevents memory exhaustion from arbitrarily large payloads
- Add comprehensive integration tests for body size limits (JSON and URL-encoded)
- Tests verify that payloads under 1MB are accepted and over 1MB are rejected with 413