### PR TITLE
Add workout indicators to calendar

### DIFF
--- a/frontend/src/screens/CalendarScreen.tsx
+++ b/frontend/src/screens/CalendarScreen.tsx
@@ -68,37 +68,72 @@ export const CalendarScreen: React.FC = () => {
   const markedDates = useMemo(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const marked: Record<string, any> = {};
+    const today = new Date().toISOString().split('T')[0];
 
+    // Mark dates with workouts - show dot but no background
     Object.keys(workoutsByDate).forEach((date) => {
       const workoutCount = workoutsByDate[date].length;
       marked[date] = {
-        marked: true,
-        dotColor: '#007AFF',
+        marked: workoutCount > 0,
+        dotColor: colors.primary,
         customStyles: {
           container: {
-            backgroundColor: workoutCount > 0 ? '#E3F2FD' : 'transparent',
+            backgroundColor: 'transparent',
             borderRadius: 16,
           },
           text: {
-            color: '#333',
+            color: colors.text,
             fontWeight: workoutCount > 0 ? '600' : '400',
           },
         },
       };
     });
 
+    // Highlight today with light background (works with or without workout)
+    if (!marked[today]) {
+      marked[today] = {
+        marked: false,
+        customStyles: {
+          container: {
+            backgroundColor: colors.highlightBackground,
+            borderRadius: 16,
+          },
+          text: {
+            color: colors.text,
+            fontWeight: '400',
+          },
+        },
+      };
+    } else {
+      // Today has a workout - keep the dot, add background
+      marked[today] = {
+        ...marked[today],
+        customStyles: {
+          container: {
+            backgroundColor: colors.highlightBackground,
+            borderRadius: 16,
+          },
+          text: {
+            color: colors.text,
+            fontWeight: '600',
+          },
+        },
+      };
+    }
+
+    // Selected date gets darker background (overrides everything)
     if (selectedDate) {
       marked[selectedDate] = {
         ...marked[selectedDate],
         selected: true,
-        selectedColor: '#007AFF',
+        selectedColor: colors.primaryAlt,
         customStyles: {
           container: {
-            backgroundColor: '#007AFF',
+            backgroundColor: colors.primaryAlt,
             borderRadius: 16,
           },
           text: {
-            color: '#fff',
+            color: colors.white,
             fontWeight: '600',
           },
         },
@@ -171,11 +206,11 @@ export const CalendarScreen: React.FC = () => {
         markedDates={markedDates}
         markingType="custom"
         theme={{
-          todayTextColor: '#007AFF',
-          selectedDayBackgroundColor: '#007AFF',
-          selectedDayTextColor: '#fff',
-          dotColor: '#007AFF',
-          arrowColor: '#007AFF',
+          todayTextColor: colors.primary,
+          selectedDayBackgroundColor: colors.primaryAlt,
+          selectedDayTextColor: colors.white,
+          dotColor: colors.primary,
+          arrowColor: colors.primary,
           textDayFontSize: 16,
           textMonthFontSize: 18,
           textMonthFontWeight: '600',

--- a/frontend/src/screens/__tests__/CalendarScreen.test.tsx
+++ b/frontend/src/screens/__tests__/CalendarScreen.test.tsx
@@ -4,12 +4,18 @@ import { CalendarScreen } from '../CalendarScreen';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigation } from '@react-navigation/native';
 import type { WorkoutSummary } from '../../types/workout.types';
+import { colors } from '../../theme';
 
 // Mock dependencies
 jest.mock('@tanstack/react-query');
 jest.mock('@react-navigation/native');
+
+// Capture the Calendar props for testing
+let capturedCalendarProps: any = null;
+
 jest.mock('react-native-calendars', () => ({
-  Calendar: jest.fn(() => {
+  Calendar: jest.fn((props) => {
+    capturedCalendarProps = props;
     const { View } = require('react-native');
     return <View testID="calendar" />;
   }),
@@ -40,6 +46,7 @@ describe('CalendarScreen', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    capturedCalendarProps = null;
     mockedUseNavigation.mockReturnValue(mockNavigation as any);
   });
 
@@ -171,6 +178,157 @@ describe('CalendarScreen', () => {
       // Assert
       expect(screen.getByText('Failed to load workouts')).toBeTruthy();
       expect(screen.getByText('Network error')).toBeTruthy();
+    });
+  });
+
+  describe('Calendar Visual Indicators', () => {
+    beforeEach(() => {
+      // Mock current date to a known value for consistent testing
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2025-11-20T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should show blue dot indicator for dates with workouts', () => {
+      // Arrange
+      const mockWorkouts: WorkoutSummary[] = [
+        {
+          id: 'workout-1',
+          name: 'Leg Day',
+          date: '2025-11-15',
+        },
+      ];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert
+      expect(capturedCalendarProps).toBeTruthy();
+      const markedDates = capturedCalendarProps.markedDates;
+      expect(markedDates['2025-11-15']).toBeDefined();
+      expect(markedDates['2025-11-15'].marked).toBe(true);
+      expect(markedDates['2025-11-15'].dotColor).toBe(colors.primary);
+    });
+
+    it('should show light background for today without removing dot for workouts', () => {
+      // Arrange - today is 2025-11-20 with a workout
+      const mockWorkouts: WorkoutSummary[] = [
+        {
+          id: 'workout-today',
+          name: 'Today Workout',
+          date: '2025-11-20',
+        },
+      ];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert
+      expect(capturedCalendarProps).toBeTruthy();
+      const markedDates = capturedCalendarProps.markedDates;
+      const todayMarking = markedDates['2025-11-20'];
+
+      // Should have both workout dot and today background
+      expect(todayMarking.marked).toBe(true);
+      expect(todayMarking.dotColor).toBe(colors.primary);
+      expect(todayMarking.customStyles.container.backgroundColor).toBe(colors.highlightBackground);
+    });
+
+    it('should show today background even without workouts', () => {
+      // Arrange - today is 2025-11-20 with NO workouts
+      const mockWorkouts: WorkoutSummary[] = [];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert
+      expect(capturedCalendarProps).toBeTruthy();
+      const markedDates = capturedCalendarProps.markedDates;
+      const todayMarking = markedDates['2025-11-20'];
+
+      // Should have today background but no dot
+      expect(todayMarking).toBeDefined();
+      expect(todayMarking.marked).toBeFalsy();
+      expect(todayMarking.customStyles.container.backgroundColor).toBe(colors.highlightBackground);
+    });
+
+    it('should use theme colors instead of hardcoded values', () => {
+      // Arrange
+      const mockWorkouts: WorkoutSummary[] = [
+        {
+          id: 'workout-1',
+          name: 'Test Workout',
+          date: '2025-11-15',
+        },
+      ];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert
+      expect(capturedCalendarProps).toBeTruthy();
+      const calendarTheme = capturedCalendarProps.theme;
+
+      // Verify theme uses colors from theme, not hardcoded blue
+      expect(calendarTheme.dotColor).toBe(colors.primary);
+      expect(calendarTheme.selectedDayBackgroundColor).toBe(colors.primaryAlt);
+      expect(calendarTheme.todayTextColor).toBe(colors.primary);
+    });
+
+    it('should not show background for workout dates that are not today', () => {
+      // Arrange
+      const mockWorkouts: WorkoutSummary[] = [
+        {
+          id: 'workout-past',
+          name: 'Past Workout',
+          date: '2025-11-15',
+        },
+      ];
+
+      mockedUseQuery.mockReturnValue({
+        data: mockWorkouts,
+        isLoading: false,
+        error: null,
+      } as any);
+
+      // Act
+      render(<CalendarScreen />);
+
+      // Assert
+      expect(capturedCalendarProps).toBeTruthy();
+      const markedDates = capturedCalendarProps.markedDates;
+      const pastDateMarking = markedDates['2025-11-15'];
+
+      // Should have dot but NO background (since it's not today)
+      expect(pastDateMarking.marked).toBe(true);
+      expect(pastDateMarking.customStyles.container.backgroundColor).toBe('transparent');
     });
   });
 });

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -54,6 +54,9 @@ export const colors = {
   // Accent colors for variety
   accentTeal: '#0D9488',
   accentForest: '#1B4332',
+
+  // Highlight colors (for selected items, today indicators, etc.)
+  highlightBackground: '#FFF1EC', // very light tint of primary for subtle highlights
 } as const;
 
 export const spacing = {


### PR DESCRIPTION
Updates the workout calendar to show:
- Orange dot under dates that have workouts
- Light background highlight for today's date
- Theme-consistent colors (burnt orange) replacing hardcoded blue

Changes:
- Add highlightBackground color token to theme for reusable subtle highlights
- Update CalendarScreen markedDates logic to distinguish between workout days and today
- Replace all hardcoded blue colors with theme tokens (primary, primaryAlt)
- Add comprehensive tests for calendar visual indicators

The new indicators follow the "Warm Athletic Performance" design system with burnt orange accents instead of generic blue.